### PR TITLE
Support for templates in the stats URL

### DIFF
--- a/cmd/kusd/config.go
+++ b/cmd/kusd/config.go
@@ -120,8 +120,9 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 	utils.RegisterKowalaService(stack, &cfg.Kowala)
 
 	// Add the Stats daemon if requested.
-	if cfg.Stats.URL != "" {
-		utils.RegisterKowalaStatsService(stack, cfg.Stats.URL)
+	statsUrl := cfg.Stats.GetURL()
+	if statsUrl != "" {
+		utils.RegisterKowalaStatsService(stack, statsUrl)
 	}
 
 	// Add the release oracle service so it boots along with node.

--- a/sample-kowala.toml
+++ b/sample-kowala.toml
@@ -36,4 +36,4 @@ TrustedNodes = []
 ListenAddr = ":30303"
 
 [Stats]
-URL = "Ricardo's node (1):DVagynuHLdn9sK6c@testnet.kowala.io:80"
+URL = "{{.Hostname}}:DVagynuHLdn9sK6c@testnet.kowala.io:80"

--- a/stats/config.go
+++ b/stats/config.go
@@ -1,5 +1,38 @@
 package stats
 
+import (
+	"bytes"
+	"html/template"
+	"os"
+)
+
 type Config struct {
 	URL string `toml:",omitempty"`
+}
+
+func (config *Config) GetURL() string {
+	tpl, err := template.New("url").Parse(config.URL)
+	if err != nil {
+		// If there's an error return the original url
+		return config.URL
+	}
+
+	var buf bytes.Buffer
+	err = tpl.Execute(&buf, map[string]string{
+		"Hostname": hostname(),
+	})
+	if err != nil {
+		// If there's an error return the original url
+		return config.URL
+	}
+
+	return buf.String()
+}
+
+func hostname() string {
+	value, err := os.Hostname()
+	if err != nil {
+		return "unknown-hostname"
+	}
+	return value
 }

--- a/stats/config_test.go
+++ b/stats/config_test.go
@@ -1,0 +1,24 @@
+package stats
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigGetURLPlain(t *testing.T) {
+	config := &Config{
+		URL: "FooBar",
+	}
+	require.Equal(t, "FooBar", config.GetURL())
+}
+
+func TestConfigGetURLTemplate(t *testing.T) {
+	config := &Config{
+		URL: "FooBar-{{.Hostname}}",
+	}
+	hn, err := os.Hostname()
+	require.NoError(t, err)
+	require.Equal(t, "FooBar-"+hn, config.GetURL())
+}


### PR DESCRIPTION
- Stats url is parsed as a template, replacing variables
- Added `Hostname` variable with the hostname of the machine running the binary.