### PR TITLE
Script to run with genesis and a new account

### DIFF
--- a/kusd.Dockerfile
+++ b/kusd.Dockerfile
@@ -11,4 +11,5 @@ COPY --from=builder /kusd/build/bin/kusd .
 EXPOSE 11223
 EXPOSE 22334
 EXPOSE 22334/udp
-ENTRYPOINT ["./kusd"]
+ADD release/kusd_with_new_account.sh .
+ENTRYPOINT ["./kusd_with_new_account.sh"]

--- a/release/kusd_with_new_account.sh
+++ b/release/kusd_with_new_account.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+trap "exit" INT
+
+cd /kusd
+
+./kusd init /kusd/genesis.json
+
+echo "test" > password.txt
+address=$(./kusd account new --password password.txt | tail -c42 | head -c40)
+
+echo ./kusd $(eval "echo $@")
+./kusd $(eval "echo $@")


### PR DESCRIPTION
Added a script in the docker image to start from a genesis (not included in the image) and with a new account.