### PR TITLE
kusd/validator: 1 second block times

### DIFF
--- a/kusd/validator/states.go
+++ b/kusd/validator/states.go
@@ -102,7 +102,7 @@ func (val *Validator) newElectionState() stateFn {
 
 	<-time.NewTimer(val.start.Sub(time.Now())).C
 
-	// @NOTE (rgeraldes) - wait for txs - sync genesis validators, first block.
+	// @NOTE (rgeraldes) - wait for txs - sync genesis validators, round zero for the first block only.
 	if val.blockNumber.Cmp(big.NewInt(1)) == 0 {
 		numTxs, _ := val.backend.TxPool().Stats() //
 		if val.round == 0 && numTxs == 0 {        //!cs.needProofBlock(height)

--- a/kusd/validator/states.go
+++ b/kusd/validator/states.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"math/big"
 	"sync/atomic"
 	"time"
 
@@ -101,18 +102,16 @@ func (val *Validator) newElectionState() stateFn {
 
 	<-time.NewTimer(val.start.Sub(time.Now())).C
 
-	/*
-		// @NOTE (rgeraldes) - wait for txs to be available in the txPool for the the first block
-		if val.blockNumber.Cmp(big.NewInt(1)) == 0 {
-			numTxs, _ := val.backend.TxPool().Stats() //
-			if val.round == 0 && numTxs == 0 {        //!cs.needProofBlock(height)
-				log.Info("Waiting for transactions")
-				txSub := val.eventMux.Subscribe(core.TxPreEvent{})
-				defer txSub.Unsubscribe()
-				<-txSub.Chan()
-			}
+	// @NOTE (rgeraldes) - wait for txs - sync genesis validators, first block.
+	if val.blockNumber.Cmp(big.NewInt(1)) == 0 {
+		numTxs, _ := val.backend.TxPool().Stats() //
+		if val.round == 0 && numTxs == 0 {        //!cs.needProofBlock(height)
+			log.Info("Waiting for a TX")
+			txSub := val.eventMux.Subscribe(core.TxPreEvent{})
+			defer txSub.Unsubscribe()
+			<-txSub.Chan()
 		}
-	*/
+	}
 
 	return val.newRoundState
 }

--- a/kusd/validator/states.go
+++ b/kusd/validator/states.go
@@ -107,9 +107,10 @@ func (val *Validator) newElectionState() stateFn {
 		numTxs, _ := val.backend.TxPool().Stats() //
 		if val.round == 0 && numTxs == 0 {        //!cs.needProofBlock(height)
 			log.Info("Waiting for a TX")
-			txSub := val.eventMux.Subscribe(core.TxPreEvent{})
+			txCh := make(chan core.TxPreEvent)
+			txSub := val.backend.TxPool().SubscribeTxPreEvent(txCh)
 			defer txSub.Unsubscribe()
-			<-txSub.Chan()
+			<-txCh
 		}
 	}
 

--- a/kusd/validator/validator.go
+++ b/kusd/validator/validator.go
@@ -264,16 +264,11 @@ func (val *Validator) init() error {
 		log.Crit("Failed to access the voters checksum", "err", err)
 	}
 
-	var start time.Time
 	if parent.NumberU64() == 0 {
-		start = time.Now()
-
 		if err := val.updateValidators(checksum, true); err != nil {
 			log.Crit("Failed to update the validator set", "err", err)
 		}
 	} else {
-		start = time.Unix(parent.Time().Int64(), 0)
-
 		// new validator set
 		if val.validatorsChecksum != checksum {
 			val.updateValidators(checksum, false)
@@ -281,8 +276,10 @@ func (val *Validator) init() error {
 		}
 	}
 
-	val.start = start.Add(time.Duration(params.SyncDuration) * time.Millisecond)
-
+	// @NOTE (rgeraldes) - start is not relevant for the first block as the first election will
+	// wait until we have transactions
+	start := time.Unix(parent.Time().Int64(), 0)
+	val.start = start.Add(time.Duration(params.BlockTime) * time.Millisecond)
 	val.blockNumber = parent.Number().Add(parent.Number(), big.NewInt(1))
 	val.round = 0
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -55,13 +55,13 @@ const (
 	Bn256PairingPerPointGas uint64 = 80000  // Per-point price for an elliptic curve pairing check
 
 	// Proof of Stake - timeouts
-	ProposeDuration        uint64 = 10000
-	ProposeDeltaDuration   uint64 = 5000
-	PreVoteDuration        uint64 = 10000
-	PreVoteDeltaDuration   uint64 = 5000
-	PreCommitDuration      uint64 = 10000
-	PreCommitDeltaDuration uint64 = 5000
-	SyncDuration           uint64 = 15000
+	ProposeDuration        uint64 = 500
+	ProposeDeltaDuration   uint64 = 25
+	PreVoteDuration        uint64 = 200
+	PreVoteDeltaDuration   uint64 = 25
+	PreCommitDuration      uint64 = 200
+	PreCommitDeltaDuration uint64 = 25
+	BlockTime              uint64 = 1000
 )
 
 var (


### PR DESCRIPTION
Important changes:
- The nodes will wait for a transaction on the first round of the first election - sync genesis validators.

Impact:
- In order to start elections, we will always need to post a transaction (ex: faucet).

Closes #78 
