### PR TITLE
shell script wasn't sending quotes properly

### DIFF
--- a/release/kusd_with_new_account.sh
+++ b/release/kusd_with_new_account.sh
@@ -7,6 +7,6 @@ cd /kusd
 ./kusd init /kusd/genesis.json
 
 echo "test" > password.txt
-address=$(./kusd account new --password password.txt | tail -c42 | head -c40)
+./kusd account new --password password.txt
 
-./kusd $(eval "echo $@")
+./kusd "$@"


### PR DESCRIPTION
Commands with quotes sent to the docker image were not working as expected. 