### PR TITLE
Feature/sync waiter - Step 1

### DIFF
--- a/kusd/validator/sync_waiter.go
+++ b/kusd/validator/sync_waiter.go
@@ -1,0 +1,30 @@
+package validator
+
+import (
+	"errors"
+	"github.com/kowala-tech/kUSD/event"
+	"github.com/kowala-tech/kUSD/kusd/downloader"
+)
+
+var (
+	errFailedEventReceived      = errors.New("FailedEvent received")
+	errFailedToReceiveDoneEvent = errors.New("failed to receive DoneEvent")
+)
+
+// SyncWaiter subscribes to DoneEvent and FailedEvent on a event.TypeMux
+// and when one of those events is received call a user function.
+// Example usage to delay Validator start after block sync has finished
+func SyncWaiter(eventMux *event.TypeMux) error {
+	events := eventMux.Subscribe(downloader.DoneEvent{}, downloader.FailedEvent{})
+	defer events.Unsubscribe()
+	for ev := range events.Chan() {
+		switch ev.Data.(type) {
+		case downloader.DoneEvent:
+			return nil
+		case downloader.FailedEvent:
+			return errFailedEventReceived
+		}
+	}
+
+	return errFailedToReceiveDoneEvent
+}

--- a/kusd/validator/sync_waiter_test.go
+++ b/kusd/validator/sync_waiter_test.go
@@ -1,0 +1,49 @@
+package validator
+
+import (
+	"github.com/kowala-tech/kUSD/event"
+	"github.com/kowala-tech/kUSD/kusd/downloader"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestSyncWaiterNoError(t *testing.T) {
+	mux := new(event.TypeMux)
+	defer mux.Stop()
+
+	go func() {
+		time.Sleep(time.Millisecond * 10)
+		err := mux.Post(downloader.DoneEvent{})
+		assert.NoError(t, err, "error posting event")
+	}()
+
+	err := SyncWaiter(mux)
+	assert.NoError(t, err, "error from SyncWaiter")
+}
+
+func TestSyncWaiterReturnErrorOnFailedEvent(t *testing.T) {
+	mux := new(event.TypeMux)
+	defer mux.Stop()
+
+	go func() {
+		time.Sleep(time.Millisecond * 10)
+		err := mux.Post(downloader.FailedEvent{})
+		assert.NoError(t, err, "error posting event")
+	}()
+
+	err := SyncWaiter(mux)
+	assert.Error(t, err, "error from SyncWaiter")
+}
+
+func TestSyncWaiterReturnsErrorOnClosedMutex(t *testing.T) {
+	mux := new(event.TypeMux)
+
+	go func() {
+		time.Sleep(time.Millisecond * 10)
+		mux.Stop()
+	}()
+
+	err := SyncWaiter(mux)
+	assert.Error(t, err, "failed to receive DoneEvent")
+}

--- a/kusd/validator/validator.go
+++ b/kusd/validator/validator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kowala-tech/kUSD/core/types"
 	"github.com/kowala-tech/kUSD/core/vm"
 	"github.com/kowala-tech/kUSD/event"
-	"github.com/kowala-tech/kUSD/kusd/downloader"
 	"github.com/kowala-tech/kUSD/kusddb"
 	"github.com/kowala-tech/kUSD/log"
 	"github.com/kowala-tech/kUSD/params"
@@ -99,27 +98,20 @@ func New(backend Backend, contractBackend bind.ContractBackend, config *params.C
 	return validator
 }
 
-// sync keeps track of the downloader events. Please be aware that this is a one shot type of update loop.
-// It's entered once and as soon as `Done` or `Failed` has been broadcasted the events are unregistered and
-// the loop is exited. This to prevent a major security vuln where external parties can DOS you with blocks
-// and halt your validation operation for as long as the DOS continues.
 func (val *Validator) sync() {
-	events := val.eventMux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
-out:
-	for ev := range events.Chan() {
-		switch ev.Data.(type) {
-		case downloader.DoneEvent, downloader.FailedEvent:
-			start := atomic.LoadInt32(&val.shouldStart) == 1
-			atomic.StoreInt32(&val.canStart, 1)
-			atomic.StoreInt32(&val.shouldStart, 0)
-			if start {
-				val.Start(val.account.Address, val.deposit)
-			}
-			// unsubscribe. we're only interested in this event once
-			events.Unsubscribe()
-			// stop immediately and ignore all further pending events
-			break out
-		}
+	if err := SyncWaiter(val.eventMux); err != nil {
+		log.Warn("Failed to sync with network", "err", err)
+	} else {
+		val.finishedSync()
+	}
+}
+
+func (val *Validator) finishedSync() {
+	start := atomic.LoadInt32(&val.shouldStart) == 1
+	atomic.StoreInt32(&val.canStart, 1)
+	atomic.StoreInt32(&val.shouldStart, 0)
+	if start {
+		val.Start(val.account.Address, val.deposit)
 	}
 }
 


### PR DESCRIPTION
A function that waits for Block Sync to finish and then calls a provided function
Example:
```
mux := new(event.TypeMux)
defer mux.Stop()
SyncWaiter(
   mux,
   func() { fmt.Print("synchronization done!) },
   func() { fmt.Print("synchronization failed!") },
)
```

