### PR TITLE
Removed GitHub release pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,21 +26,6 @@ pipeline:
       event: [push, tag]
       branch: [master, dev, refs/tags/*]
 
-  github_release:
-    image: plugins/github-release
-    secrets: [ github_release_api_key ] 
-    files:
-      - build/bin/kusd
-    checksum:
-      - md5
-      - sha1
-      - sha256
-      - sha512
-      - adler32
-      - crc32
-    when:
-      event: tag
-
   docker_kusd_dev:
     group: docker-deployment
     image: plugins/docker


### PR DESCRIPTION
This removes the CI pipeline that creates a GitHub release on tag push. Instead of doing that, we'll manually create releases in GH which will create tags, which will in turn trigger all the appropriate CI tasks, including the Docker image pushes. 
