### PR TITLE
CI Slack notifications

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -93,8 +93,7 @@ pipeline:
     group: notify
     image: plugins/slack
     secrets: [ slack_webhook ] 
-    #channel: dev
-    recipient: paul.fox
+    channel: dev
     username: kowala-tech/core drone
     template: >
         *CI build #{{build.number}}* on branch {{build.branch}} *{{#success build.status}}successful{{else}}failed{{/success}}* in {{since build.started}}
@@ -102,5 +101,6 @@ pipeline:
         > ${DRONE_COMMIT_MESSAGE}
         
         {{#if build.tag}}`v{{build.tag}}` | {{/if}}Commit <${DRONE_COMMIT_LINK}|{{build.commit}}> | <{{build.link}}|Build #{{build.number}}>
-    #when:
-        #branch: [dev] 
+    when:
+      event: [push, tag]
+      branch: [master, dev, refs/tags/*]

--- a/.drone.yml
+++ b/.drone.yml
@@ -97,9 +97,10 @@ pipeline:
     recipient: paul.fox
     username: kowala-tech/core drone
     template: >
-        *Build #{{build.number}}* on branch {{build.branch}} *{{#success build.status}}successful{{else}}failed{{/success}}* in {{since build.started}}
+        *CI build #{{build.number}}* on branch {{build.branch}} *{{#success build.status}}successful{{else}}failed{{/success}}* in {{since build.started}}
+
         > ${DRONE_COMMIT_MESSAGE}
         
-        {{#if build.tag}}`v{{build.tag}}` | {{/if}}<${DRONE_COMMIT_LINK}|{{build.commit}}> | <{{build.link}}|Build #{{build.number}}>
+        {{#if build.tag}}`v{{build.tag}}` | {{/if}}Commit <${DRONE_COMMIT_LINK}|{{build.commit}}> | <{{build.link}}|Build #{{build.number}}>
     #when:
         #branch: [dev] 

--- a/.drone.yml
+++ b/.drone.yml
@@ -89,3 +89,17 @@ pipeline:
     when:
       event: tag
 
+  notify-dev:
+    group: notify
+    image: plugins/slack
+    secrets: [ slack_webhook ] 
+    #channel: dev
+    recipient: paul.fox
+    username: kowala-tech/core drone
+    template: >
+        *Build #{{build.number}}* on branch {{build.branch}} *{{#success build.status}}successful{{else}}failed{{/success}}* in {{since build.started}}
+        > ${DRONE_COMMIT_MESSAGE}
+        
+        {{#if build.tag}}`v{{build.tag}}` | {{/if}}<${DRONE_COMMIT_LINK}|{{build.commit}}> | <{{build.link}}|Build #{{build.number}}>
+    #when:
+        #branch: [dev] 


### PR DESCRIPTION
A small CI change to push Slack notifications into the #dev Slack channel when CI completes (successfully or unsuccessfully) on the `master` and `dev` branches, and also on tag pushes. This will not trigger on feature branches, because that would be annoying.

The only reasons to have this is so that everyone knows when new versions are ready for use, and when a new release is made.

The Slack messages look a bit like this (you'll have to imagine the formatting and links):

```
*CI build #641* on branch hotfix/some-branch *successful* in 1m30s

> Last commit message here
v1.0.3 | Commit 4098b3689c8a5fe9ca7c3ea3f9cf138a6c8b3f57 | Build #641
```

Does this seem useful? Any objections or possible improvements?