### PR TITLE
replaced a panic log with a warn on validator start if coinbase is no…

### DIFF
--- a/kusd/backend.go
+++ b/kusd/backend.go
@@ -145,7 +145,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Kowala, error) {
 	networkContract := getNetworkContract(kusd.BlockChain(), NewContractBackend(kusd.ApiBackend))
 	walletAccount, err := getWalletAccount(ctx.AccountManager, kusd.coinbase)
 	if err != nil {
-		log.Crit("failed to get wallet account", "err", err)
+		log.Warn("failed to get wallet account", "err", err)
 	}
 	kusd.validator = validator.New(walletAccount, kusd, networkContract, kusd.chainConfig, kusd.EventMux(), kusd.engine, vmConfig)
 	kusd.validator.SetExtra(makeExtraData(config.ExtraData))

--- a/kusd/validator/validator.go
+++ b/kusd/validator/validator.go
@@ -129,7 +129,12 @@ func (val *validator) Start(coinbase common.Address, deposit uint64) {
 
 	atomic.StoreInt32(&val.shouldStart, 1)
 
-	newWalletAccount, _ := accounts.NewWalletAccount(val.walletAccount, accounts.Account{Address: coinbase})
+	newWalletAccount, err := accounts.NewWalletAccount(val.walletAccount, accounts.Account{Address: coinbase})
+	if err != nil {
+		log.Warn("error setting coinbase on validator start", "err", err)
+		return
+	}
+
 	val.walletAccount = newWalletAccount
 	val.deposit = deposit
 


### PR DESCRIPTION
Fixes node start failure on validator is a coinbase is not set on startup

Closes #124
