### PR TITLE
Feature/drone rename

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -94,7 +94,7 @@ pipeline:
     image: plugins/slack
     secrets: [ slack_webhook ] 
     channel: dev
-    username: kowala-tech/core drone
+    username: kowala-tech/kUSD drone
     template: >
         *CI build #{{build.number}}* on branch {{build.branch}} *{{#success build.status}}successful{{else}}failed{{/success}}* in {{since build.started}}
 


### PR DESCRIPTION
This is a tiny fix that renames the Drone.io Slackbot to 'kUSD' (it was 'core', which is the same as s different Slackbot that we also use).