### PR TITLE
removed from git ignore non project related files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,38 +4,10 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile ~/.gitignore_global
 
-/tmp
-*/**/*un~
-*/**/*.test
-*un~
-.DS_Store
-*/**/.DS_Store
-.ethtest
-*/**/*tx_database*
-*/**/*dapps*
-build/_vendor/pkg
-pkg
-bin
-
-#*
-.#*
-*#
-*~
-.project
-.settings
-.kowala
-
 # used by the Makefile
 /build/_workspace/
 /build/bin/
 /kusd*.zip
-
-# travis
-profile.tmp
-profile.cov
-
-# IdeaIDE
-.idea
 
 # dashboard
 /dashboard/assets/node_modules


### PR DESCRIPTION
Git ignore should only have files and folders related to build tools.
Platform specific files should be added on your local global .gitignore

```
# See http://help.github.com/ignore-files/ for more about ignoring files.	 
#	 
# If you find yourself ignoring temporary files generated by your text editor	 
# or operating system, you probably want to add a global ignore instead:	
#   git config --global core.excludesfile ~/.gitignore_global	
```