### PR TITLE
Log errors when deposit fails

### DIFF
--- a/kusd/validator/states.go
+++ b/kusd/validator/states.go
@@ -45,6 +45,7 @@ func (val *validator) notLoggedInState() stateFn {
 
 		log.Info("Making Deposit")
 		if err := val.makeDeposit(); err != nil {
+			log.Error("Error making deposit", "err", err)
 			return nil
 		}
 


### PR DESCRIPTION
Prints out an error to the logs when the make deposit fails.